### PR TITLE
NamedNode.php: explicitly set type "string" for $iri property

### DIFF
--- a/src/quickRdf/NamedNode.php
+++ b/src/quickRdf/NamedNode.php
@@ -35,11 +35,7 @@ use quickRdf\DataFactory as DF;
  */
 class NamedNode implements \rdfInterface\NamedNode, HashableTerm {
 
-    /**
-     *
-     * @var string
-     */
-    private $iri;
+    private string $iri;
 
     public function __construct(string $iri) {
         (!DF::$enforceConstructor) || DF::checkCall();


### PR DESCRIPTION
This change uses property datatypes since PHP 8.0 and improves code readability IMHO.