### PR TITLE
Reached PHPStan (v2) level 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=8.0",
         "zozlak/rdf-constants": "^1.1",
-        "sweetrdf/rdf-interface": "^2",
+        "sweetrdf/rdf-interface": "^2 | ^3",
         "sweetrdf/rdf-helpers": "^2",
         "sweetrdf/term-templates": "^2.0.2"
     },
@@ -30,7 +30,7 @@
     "require-dev": {
         "phpunit/phpunit": "*",
         "phpstan/phpstan": "^2",
-        "sweetrdf/rdf-interface-tests": "2.0.0",
+        "sweetrdf/rdf-interface-tests": "3.0.0",
         "sweetrdf/simple-rdf": "^2"
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "*",
-        "phpstan/phpstan": "^1",
+        "phpstan/phpstan": "^2",
         "sweetrdf/rdf-interface-tests": "2.0.0",
         "sweetrdf/simple-rdf": "^2"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,7 +5,7 @@ parameters:
     fileExtensions:
         - php
 
-    level: 4
+    level: 6
 
     paths:
         - src
@@ -14,3 +14,5 @@ parameters:
         maximumNumberOfProcesses: 4
 
     tmpDir: /tmp/phpstan
+
+    treatPhpDocTypesAsCertain: false 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,16 @@
+parameters:
+    bootstrapFiles:
+        - vendor/autoload.php
+
+    fileExtensions:
+        - php
+
+    level: 4
+
+    paths:
+        - src
+
+    parallel:
+        maximumNumberOfProcesses: 4
+
+    tmpDir: /tmp/phpstan

--- a/src/quickRdf/DataFactory.php
+++ b/src/quickRdf/DataFactory.php
@@ -195,7 +195,9 @@ class DataFactory implements iDataFactory {
      * @return iQuad
      */
     public static function importQuad(iQuad $quad): iQuad {
-        return self::importTerm($quad);
+        /** @var iQuad */
+        $quad = self::importTerm($quad);
+        return $quad;
     }
 
     public static function checkCall(): bool {

--- a/src/quickRdf/DataFactory.php
+++ b/src/quickRdf/DataFactory.php
@@ -178,8 +178,10 @@ class DataFactory implements iDataFactory {
             $graph = $term->getGraph();
             if ($recursive) {
                 $sbj   = self::importTerm($sbj, $recursive);
+                /** @var iQuad */
                 $pred  = self::importTerm($pred, $recursive);
                 $obj   = self::importTerm($obj, $recursive);
+                /** @var iNamedNode|iBlankNode|iDefaultGraph */
                 $graph = self::importTerm($graph, $recursive);
             }
             return self::quad($sbj, $pred, $obj, $graph);

--- a/src/quickRdf/Dataset.php
+++ b/src/quickRdf/Dataset.php
@@ -111,7 +111,7 @@ class Dataset implements DatasetInterface {
         // $other contained in $this
         foreach ($other as $i) {
             if (!($i->getSubject() instanceof BlankNodeInterface) && !($i->getObject() instanceof BlankNodeInterface)) {
-                if ($i instanceof Quad) {
+                if (!($i instanceof Quad)) {
                     $i = DataFactory::importQuad($i);
                 }
                 if (!isset($this->quads[$i])) {
@@ -131,7 +131,7 @@ class Dataset implements DatasetInterface {
 
     /**
      * 
-     * @param \rdfInterface\QuadInterface|\rdfInterface\QuadIteratorAggregateInterface|\rdfInterface\QuadIteratorInterface|array<\rdfInterface\QuadInterface> $quads
+     * @param QuadInterface|\Traversable<QuadInterface>|array<QuadInterface> $quads
      * @return void
      */
     public function add(QuadInterface | \Traversable | array $quads): void {
@@ -231,7 +231,7 @@ class Dataset implements DatasetInterface {
 
     /**
      *
-     * @param QuadCompareInterface|callable|int<0, max> $offset
+     * @param QuadCompareInterface|callable|int<0, 0> $offset
      * @return bool
      * @throws UnexpectedValueException
      * @throws MultipleQuadsMatchedException
@@ -250,7 +250,7 @@ class Dataset implements DatasetInterface {
 
     /**
      *
-     * @param QuadCompareInterface|callable|int<0, max> $offset
+     * @param QuadCompareInterface|callable|int<0, 0> $offset
      * @return QuadInterface
      * @throws UnexpectedValueException
      * @throws MultipleQuadsMatchedException
@@ -269,7 +269,7 @@ class Dataset implements DatasetInterface {
 
     /**
      *
-     * @param QuadCompareInterface|callable|null|mixed $offset
+     * @param QuadCompareInterface|callable|null $offset
      * @param QuadInterface $value
      * @return void
      * @throws UnexpectedValueException
@@ -299,7 +299,7 @@ class Dataset implements DatasetInterface {
 
     /**
      *
-     * @param QuadCompareInterface|callable|mixed $offset
+     * @param QuadCompareInterface|callable $offset
      * @return void
      * @throws UnexpectedValueException
      * @throws MultipleQuadsMatchedException
@@ -390,7 +390,7 @@ class Dataset implements DatasetInterface {
 
     /**
      *
-     * @param QuadCompareInterface|QuadIteratorInterface|QuadIteratorAggregateInterface|callable|int<0, max>|null $offset
+     * @param QuadCompareInterface|QuadIteratorInterface|QuadIteratorAggregateInterface|callable|int<0, 0>|null $offset
      * @return Generator<QuadInterface>
      * @throws UnexpectedValueException
      */

--- a/src/quickRdf/Dataset.php
+++ b/src/quickRdf/Dataset.php
@@ -111,7 +111,7 @@ class Dataset implements DatasetInterface {
         // $other contained in $this
         foreach ($other as $i) {
             if (!($i->getSubject() instanceof BlankNodeInterface) && !($i->getObject() instanceof BlankNodeInterface)) {
-                if (!($i instanceof Quad) && $i !== null) {
+                if ($i instanceof Quad) {
                     $i = DataFactory::importQuad($i);
                 }
                 if (!isset($this->quads[$i])) {
@@ -131,7 +131,7 @@ class Dataset implements DatasetInterface {
 
     /**
      * 
-     * @param QuadInterface|\Traversable<\rdfInterface\QuadInterface>|array<\rdfInterface\QuadInterface> $quads
+     * @param \rdfInterface\QuadInterface|\rdfInterface\QuadIteratorAggregateInterface|\rdfInterface\QuadIteratorInterface|array<\rdfInterface\QuadInterface> $quads
      * @return void
      */
     public function add(QuadInterface | \Traversable | array $quads): void {
@@ -231,7 +231,7 @@ class Dataset implements DatasetInterface {
 
     /**
      *
-     * @param QuadCompareInterface|callable|int<0, 0> $offset
+     * @param QuadCompareInterface|callable|int<0, max> $offset
      * @return bool
      * @throws UnexpectedValueException
      * @throws MultipleQuadsMatchedException
@@ -250,7 +250,7 @@ class Dataset implements DatasetInterface {
 
     /**
      *
-     * @param QuadCompareInterface|callable|int<0, 0> $offset
+     * @param QuadCompareInterface|callable|int<0, max> $offset
      * @return QuadInterface
      * @throws UnexpectedValueException
      * @throws MultipleQuadsMatchedException
@@ -269,7 +269,7 @@ class Dataset implements DatasetInterface {
 
     /**
      *
-     * @param QuadCompareInterface|callable|null $offset
+     * @param QuadCompareInterface|callable|null|mixed $offset
      * @param QuadInterface $value
      * @return void
      * @throws UnexpectedValueException
@@ -299,7 +299,7 @@ class Dataset implements DatasetInterface {
 
     /**
      *
-     * @param QuadCompareInterface|callable $offset
+     * @param QuadCompareInterface|callable|mixed $offset
      * @return void
      * @throws UnexpectedValueException
      * @throws MultipleQuadsMatchedException
@@ -390,7 +390,7 @@ class Dataset implements DatasetInterface {
 
     /**
      *
-     * @param QuadCompareInterface|QuadIteratorInterface|QuadIteratorAggregateInterface|callable|int<0, 0>|null $offset
+     * @param QuadCompareInterface|QuadIteratorInterface|QuadIteratorAggregateInterface|callable|int<0, max>|null $offset
      * @return Generator<QuadInterface>
      * @throws UnexpectedValueException
      */

--- a/src/quickRdf/DatasetNode.php
+++ b/src/quickRdf/DatasetNode.php
@@ -55,7 +55,7 @@ class DatasetNode implements DatasetNodeInterface {
     /**
      * 
      * @param TermInterface|null $node
-     * @param \rdfInterface\QuadInterface|\rdfInterface\QuadIteratorInterface|\rdfInterface\QuadIteratorAggregateInterface|\rdfInterface\QuadNoSubjectInterface|Traversable<\rdfInterface\QuadInterface>|array<\rdfInterface\QuadInterface>|null $quads
+     * @param QuadInterface|QuadNoSubjectInterface|Traversable<QuadInterface|QuadNoSubjectInterface>|array<QuadInterface|QuadNoSubjectInterface>|null $quads
      * @return DatasetNodeInterface
      * @throws BadMethodCallException
      */
@@ -70,8 +70,13 @@ class DatasetNode implements DatasetNodeInterface {
     private DatasetInterface $dataset;
     private TermInterface $node;
 
+    /**
+     * 
+     * @param TermInterface $node
+     * @param QuadInterface|QuadNoSubjectInterface|Traversable<QuadInterface|QuadNoSubjectInterface>|array<QuadInterface|QuadNoSubjectInterface>|null $quads
+     */
     public function __construct(TermInterface $node,
-                                QuadIteratorInterface | QuadIteratorAggregateInterface | null $quads = null,
+                                QuadInterface | QuadNoSubjectInterface | Traversable | array | null $quads = null,
                                 bool $indexed = true) {
         $this->node    = $node;
         $this->dataset = new Dataset($indexed);
@@ -192,7 +197,7 @@ class DatasetNode implements DatasetNodeInterface {
 
     /**
      * 
-     * @param QuadCompareInterface|callable|int<0, max> $offset
+     * @param QuadCompareInterface|callable|int<0, 0> $offset
      * @return bool
      * @throws UnexpectedValueException
      * @throws MultipleQuadsMatchedException
@@ -232,7 +237,7 @@ class DatasetNode implements DatasetNodeInterface {
 
     /**
      * 
-     * @param QuadCompareInterface|callable|int<0, max> $offset
+     * @param QuadCompareInterface|callable|int<0, 0> $offset
      * @return void
      * @throws UnexpectedValueException
      * @throws MultipleQuadsMatchedException

--- a/src/quickRdf/DatasetNode.php
+++ b/src/quickRdf/DatasetNode.php
@@ -55,7 +55,7 @@ class DatasetNode implements DatasetNodeInterface {
     /**
      * 
      * @param TermInterface|null $node
-     * @param QuadInterface|QuadNoSubjectInterface|Traversable<QuadInterface|QuadNoSubjectInterface>|array<QuadInterface|QuadNoSubjectInterface>|null $quads
+     * @param \rdfInterface\QuadInterface|\rdfInterface\QuadIteratorInterface|\rdfInterface\QuadIteratorAggregateInterface|\rdfInterface\QuadNoSubjectInterface|Traversable<\rdfInterface\QuadInterface>|array<\rdfInterface\QuadInterface>|null $quads
      * @return DatasetNodeInterface
      * @throws BadMethodCallException
      */
@@ -192,7 +192,7 @@ class DatasetNode implements DatasetNodeInterface {
 
     /**
      * 
-     * @param QuadCompareInterface|callable|int<0, 0> $offset
+     * @param QuadCompareInterface|callable|int<0, max> $offset
      * @return bool
      * @throws UnexpectedValueException
      * @throws MultipleQuadsMatchedException
@@ -232,7 +232,7 @@ class DatasetNode implements DatasetNodeInterface {
 
     /**
      * 
-     * @param QuadCompareInterface|callable $offset
+     * @param QuadCompareInterface|callable|int<0, max> $offset
      * @return void
      * @throws UnexpectedValueException
      * @throws MultipleQuadsMatchedException


### PR DESCRIPTION
Upgraded to PHPStan ^2 and refined a few files to reach PHPStan level 4.

Most of the stuff was straight forward, but https://github.com/sweetrdf/quickRdf/compare/feature/reached-phpstan-level-4?expand=1#diff-2ac3ab555f02af7277f4747e5909acdbe07512e1b8fe5039982db4cf5d44d69fL114 looks weird. As far as I can tell, `$other` is an array or iterable/traversable of some kind which only contains instances of `QuadInterface`. Is that correct? If so, that if-clause makes no sense. But with that change one of the rdfInterface-tests fails: https://github.com/sweetrdf/quickRdf/actions/runs/14572208914/job/40871382259#step:6:21

What do you think?